### PR TITLE
Consistently use strings for Spec keys

### DIFF
--- a/lib/deep_preloader/polymorphic_spec.rb
+++ b/lib/deep_preloader/polymorphic_spec.rb
@@ -15,7 +15,7 @@ class DeepPreloader::PolymorphicSpec < DeepPreloader::AbstractSpec
   end
 
   def initialize(specs_by_type = {})
-    @specs_by_type = specs_by_type
+    @specs_by_type = specs_by_type.transform_keys(&:to_s)
   end
 
   def polymorphic?

--- a/lib/deep_preloader/spec.rb
+++ b/lib/deep_preloader/spec.rb
@@ -11,11 +11,11 @@ class DeepPreloader::Spec < DeepPreloader::AbstractSpec
       end
     when Hash
       assoc_specs = data.each_with_object({}) do |(k, v), h|
-        h[k.to_sym] = parse(v)
+        h[k.to_s] = parse(v)
       end
       self.new(assoc_specs)
     when String, Symbol
-      self.new({ data.to_sym => nil })
+      self.new({ data.to_s => nil })
     when DeepPreloader::AbstractSpec
       data
     when nil
@@ -26,7 +26,7 @@ class DeepPreloader::Spec < DeepPreloader::AbstractSpec
   end
 
   def initialize(association_specs = {})
-    @association_specs = association_specs
+    @association_specs = association_specs.transform_keys(&:to_s)
   end
 
   def merge!(other)

--- a/lib/deep_preloader/version.rb
+++ b/lib/deep_preloader/version.rb
@@ -1,3 +1,3 @@
 class DeepPreloader
-  VERSION = '1.0.2'
+  VERSION = '1.1.0'
 end

--- a/spec/unit/deep_preloader_spec.rb
+++ b/spec/unit/deep_preloader_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe DeepPreloader do
 
   it 'can parse a hash spec' do
     spec          = { a: [:b, { c: :d, e: nil }] }
-    expected_spec = DeepPreloader::Spec.new(a: DeepPreloader::Spec.new(b: nil, c: DeepPreloader::Spec.new(d: nil), e: nil))
+    expected_spec = DeepPreloader::Spec.new('a' => DeepPreloader::Spec.new('b' => nil, 'c' => DeepPreloader::Spec.new('d' => nil), 'e' => nil))
 
     expect(DeepPreloader::Spec.parse(spec)).to eq(expected_spec)
   end
@@ -38,8 +38,8 @@ RSpec.describe DeepPreloader do
     with_temporary_table(:model)
 
     it 'can parse a polymorphic hash spec' do
-      parsed_spec   = DeepPreloader::Spec.parse(a: DeepPreloader::PolymorphicSpec.parse('Model' => { b: :c }))
-      expected_spec = DeepPreloader::Spec.new(a: DeepPreloader::PolymorphicSpec.new('Model' => DeepPreloader::Spec.new(b: DeepPreloader::Spec.new(c: nil))))
+      parsed_spec   = DeepPreloader::Spec.parse(a: DeepPreloader::PolymorphicSpec.parse('Model': { b: :c }))
+      expected_spec = DeepPreloader::Spec.new('a' => DeepPreloader::PolymorphicSpec.new('Model' => DeepPreloader::Spec.new('b' => DeepPreloader::Spec.new('c' => nil))))
 
       expect(parsed_spec).to eq(expected_spec)
     end


### PR DESCRIPTION
As it turns out we'd inconsistently used symbols (in #parse) and strings (largely from iknow_view_models) interchangeably, which was not only ugly but also prevented correct `merge!`ing. The string convention is used in many more places, so settle on that.